### PR TITLE
[이도엽] Sprint 3

### DIFF
--- a/index.css
+++ b/index.css
@@ -403,3 +403,15 @@ footer {
     padding: 0 12.5rem;
   }
 }
+
+@media screen and (min-width: 1200px) {
+
+}
+
+@media screen and (min-width: 744px) and (max-width: 1199px) {
+
+}
+
+@media screen and (min-width: 375px) and (max-width: 743px) {
+
+}

--- a/index.css
+++ b/index.css
@@ -24,11 +24,11 @@
 body {
   margin: 0 auto;
   width: 100%;
+  height: auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  overflow-x: hidden;
 }
 
 /*header*/
@@ -103,15 +103,14 @@ header button {
 .panda_1 {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
   position: relative;
-  top: 6.25rem;
 }
 
 .perdiv {
   position: relative;
-  bottom: 1rem;
+  bottom: 7rem;
 }
 
 .perdiv h1 {
@@ -153,7 +152,7 @@ header button {
 /* section */
 
 .section {
-  width: 120rem;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -163,6 +162,7 @@ header button {
 }
 
 .check, .register, .search {
+  width: 1920px;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -176,7 +176,6 @@ header button {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8.625rem;
   margin-right: 22.5rem;
 }
 
@@ -189,7 +188,7 @@ header button {
 .smallbox, .smallbox2, .smallbox3 {
   display: flex;
   flex-direction: column;
-  margin-right: 1.25rem;
+  margin-right: 1.7rem;
   gap: 1.25rem;
 }
 
@@ -242,7 +241,7 @@ header button {
 }
 
 .bigbox2 {
-  margin: 0 0 0 36.9375rem;;
+  margin: 0 0 0 35.3rem;;
 }
 
 .search h5, .search h2, .search h4 {
@@ -250,15 +249,17 @@ header button {
 }
 
 /* register add-element */
-
+.register{
+  margin-bottom: 8.625rem;
+}
 .smallbox3 {
-  padding-left: 2.5rem;
+  padding-left: 1.3rem;
 }
 
 /* block */
 
 .block {
-  width: 120rem;
+  width: 100%;
   height: 9.375rem;
   background-color: var(--secondary-color-gray);
   display: flex;
@@ -281,14 +282,12 @@ header button {
   justify-content: center;
 }
 
-.up_footer > div {
-  height: 24.8125rem;
+.upFooterIn {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
   position: relative;
-  top: 8.9375rem;
 }
 
 .up_footer h1 {
@@ -304,10 +303,13 @@ header button {
 .up_footer img {
   width: 46.625rem;
   height: 24.8125rem;
+  position: relative;
+  top: 0.1rem;
 }
 
 .trustdiv {
-  padding-bottom: 3.75rem;
+  position: relative;
+  bottom: 11rem;
   gap: 10px;
   margin-top: 3.75rem;
 }
@@ -382,8 +384,13 @@ footer {
   body {
     background-color: var(--background-color);
   }
-  .section {
+  .section{
+    width: 120rem;
     background-color: var(--white-color);
+  }
+  .block{
+    width: 120rem;
+    
   }
   header, footer {
     width: 120rem;
@@ -394,6 +401,9 @@ footer {
 }
 
 @media screen and (max-width: 1919px) {
+  body {
+    padding: auto;
+  }
   .header {
     width: 100%;
     padding: 0 12.5rem;
@@ -405,13 +415,145 @@ footer {
 }
 
 @media screen and (min-width: 1200px) {
-
-}
+  .header img{
+    width: 40px;
+    height: 40.14px;
+  }
+  .purchase img{
+    width: 746px;
+    height: 340px;
+  }
+  .check img, .search img, .register img{
+    width: 588px;
+    height: 444px;
+  }
+  .up_footer img{
+    width: 746px;
+    height: 397px;
+  }
+  .sns_a img{
+    width: 20px;
+    height: 20px;
+  }
+} /* PC */
 
 @media screen and (min-width: 744px) and (max-width: 1199px) {
-
-}
+  .header{
+    width: 100%;
+    padding: 0 1.5rem;
+  }
+  .footerbox {
+    width: 100%;
+    padding: 0 1.5rem;
+  }
+} /* Tablet */
 
 @media screen and (min-width: 375px) and (max-width: 743px) {
+  .header{
+    width: 100%;
+    padding: 0 1rem;
+  }
+  .footerbox {
+    width: 100%;
+    padding: 0 1rem;
+  }
+  /* panda 1 */
+  .purchase{
+    width: 100%;
+    height: 16rem;
+    display: flex;
+  }
+  .panda1, .perdiv {
+    width: 100%;
+    padding: 0 2rem;
+    position: relative;
+    bottom: 1rem;
+  }
+  .purchase img {
+    padding: 0 2rem 0 0;
+    width: 100%;
+    height: auto;
+  }
+  .perdiv h1 {
+    position: relative;
+    left: 3rem;
+    width: 100%;
+    font-size: 1.5rem;
+  }
+  .perdiv button {
+    position: relative;
+    left: 2rem;
+    width: 80%;
+    font-size: 1rem;
+    position: relative;
+    bottom: 1rem;
+  }
 
-}
+  /* section */
+  .section {
+    position: relative;
+    bottom: 1rem;
+    display: flex;
+    justify-content: center;
+  }
+  .check, .search, .register{
+    width: 100%;
+  }
+  .check img, .search img, .register img {
+    width: 50%;
+    height: auto;
+    padding: 0 2rem;
+  }
+  .bigbox, .bigbox2, .bigbox3 {
+    width: 100%;
+    height: auto;
+    margin: 0;
+  }
+  .smallbox, .smallbox2, .smallbox3{
+    width: 100%;
+  }
+  .onetext h2, .onetext2 h2, .onetext3 h2 {
+    font-size: 1.5rem;
+  }
+  .onetext h4, .onetext2 h4, .onetext3 h4{
+    font-size: 0.9rem;
+  }
+  .smallbox h5, .smallbox2 h5, .smallbox3 h5{
+    position: relative;
+    top: 0.7rem;
+  }
+
+  /* panda2 */
+  .up_footer{
+    height: 16rem;
+  }
+  .upFooterIn{
+    position: relative;
+    padding: 0 2rem;
+  }
+  .trustdiv{
+    width: 100%;
+    position: relative;
+    left: 1rem;
+    bottom: 2rem;
+  }
+  .trustdiv h1 {
+    font-size: 1.5rem;
+  }
+  .upFooterIn{
+    width: 100%;
+    height: auto;
+  }
+  .up_footer img{
+    padding: 0 0 0 2rem;
+    width: 100%;
+    height: auto;
+  }
+  /* footer */
+  .footerbox {
+    font-size: 0.7rem;
+  }
+  .sns_a img {
+    width: 100%;
+  }
+} /* Mobile */

--- a/index.css
+++ b/index.css
@@ -469,10 +469,7 @@ footer {
 @media screen and (min-width: 375px) and (max-width: 744px) {
   /* header */
   .header{
-    width: 100%;
     padding: 0 1rem;
-    display: flex;
-    justify-content: space-between;
   }
   .navPlus{
     gap: 0.5rem;

--- a/index.css
+++ b/index.css
@@ -16,9 +16,11 @@
 	--secondary-color-gray300: #E6F2FF;
 	--secondary-color-gray400: #F9FAFB;
 	--secondary-color-gray500: #DFDFDF;
+  --secondary-color-gray600: #4B5563;
 	--secondary-color-black: #1F2937;
 	--yellyow-color: #F5E14B;
 	--secondary-color-blue: #3182F6;
+  
 }
 
 body {
@@ -48,9 +50,9 @@ header {
 .header {
   max-width: 120rem;
   height: 4.375rem;
-  padding: 0.5625rem 25rem;
   display: flex;
   flex-direction: row;
+  padding: 0 ;
   justify-content: space-between;
   align-items: center;
 }
@@ -58,7 +60,7 @@ header {
 .sub_header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 0.625rem;
 }
 
@@ -68,7 +70,7 @@ header {
   cursor: pointer;
 }
 
-header h1 {
+.sub_header h1 {
   font-size: 1.601875rem;
   font-weight: 700;
   font-family: ROKAF Sans;
@@ -89,6 +91,16 @@ header button {
   cursor: pointer;
 }
 
+.sub_header h2{
+  color: var(--secondary-color-gray600);
+  font-family: Pretendard;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 21.48px;
+  white-space: nowrap;
+  margin-left: 2rem;
+}
+
 /* panda_1 */
 
 .purchase {
@@ -106,6 +118,7 @@ header button {
   align-items: flex-end;
   justify-content: center;
   position: relative;
+  gap: 1rem;
 }
 
 .perdiv {
@@ -145,8 +158,7 @@ header button {
 .purchase img {
   width: 46.625rem;
   height: 21.25rem;
-  position: relative;
-  left: 0.625rem;
+  
 }
 
 /* section */
@@ -208,7 +220,6 @@ header button {
   color: var(--blue-color);
   position: relative;
   bottom: 1.25rem;
-  white-space: nowrap;
 }
 
 .check h2, .search h2, .register h2 {
@@ -220,7 +231,6 @@ header button {
   letter-spacing: 0.02em;
   color: var(--gray-color);
   position: relative;
-  white-space: nowrap;
 }
 
 .check h4, .search h4, .register h4 {
@@ -231,7 +241,6 @@ header button {
   text-align: left;
   color: var(--gray-color);
   position: relative;
-  white-space: nowrap;
 }
 
 /* serach add-element*/
@@ -328,16 +337,13 @@ footer {
 
 .footerbox {
   width: 120rem;
-  height: 10rem;
-  padding: 2rem 25rem;
+  margin: 2rem 0 ;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.625rem;
   text-align: center;
-  position: relative;
-  bottom: 2rem;
 }
 
 .copy_txt h4{
@@ -396,13 +402,17 @@ footer {
     width: 120rem;
   }
   .header {
-    gap: 52rem;
+    gap: 30rem;
+    padding: 0 12.5rem;
   }
 }
 
 @media screen and (max-width: 1919px) {
   body {
     padding: auto;
+  }
+  .header{
+    width: 120rem;
   }
   .header {
     width: 100%;
@@ -412,8 +422,10 @@ footer {
     width: 100%;
     padding: 0 12.5rem;
   }
+
 }
 
+/* PC */
 @media screen and (min-width: 1200px) {
   .header img{
     width: 40px;
@@ -435,9 +447,14 @@ footer {
     width: 20px;
     height: 20px;
   }
-} /* PC */
+  .header {
+    width: 100%;
+    padding: 0 12.5rem;
+  }
+} 
 
-@media screen and (min-width: 744px) and (max-width: 1199px) {
+/* Tablet */
+@media screen and (max-width: 1199px) {
   .header{
     width: 100%;
     padding: 0 1.5rem;
@@ -446,49 +463,60 @@ footer {
     width: 100%;
     padding: 0 1.5rem;
   }
-} /* Tablet */
+} 
 
-@media screen and (min-width: 375px) and (max-width: 743px) {
+/* mobile */
+@media screen and (min-width: 375px) and (max-width: 744px) {
+  /* header */
   .header{
     width: 100%;
     padding: 0 1rem;
-  }
-  .footerbox {
-    width: 100%;
-    padding: 0 1rem;
-  }
-  /* panda 1 */
-  .purchase{
-    width: 100%;
-    height: 16rem;
     display: flex;
+    justify-content: space-between;
   }
-  .panda1, .perdiv {
+  .navPlus{
+    gap: 0.5rem;
+    margin: 0 0.5rem;
+  }
+  .sub_header h1{
+    font-size: 1.2rem;
+  }
+  .sub_header h2{
+    font-size: 0.8rem;
+    margin: 0 1rem
+  }
+  .hedaer button{
+    width: 50%;
+    padding: 0 1rem 0 0;
+  }
+
+  
+  /* panda 1 */
+  .purchase, .panda_1{
     width: 100%;
-    padding: 0 2rem;
+  }
+  .perdiv{
+    width: 100%;
+    position: absolute;
+    bottom: 20rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .perdiv h1{
+    font-size: 2rem;
+    text-align: center;
+  }
+  .perdiv button{
     position: relative;
     bottom: 1rem;
   }
   .purchase img {
-    padding: 0 2rem 0 0;
-    width: 100%;
+    width:100%;
     height: auto;
   }
-  .perdiv h1 {
-    position: relative;
-    left: 3rem;
-    width: 100%;
-    font-size: 1.5rem;
-  }
-  .perdiv button {
-    position: relative;
-    left: 2rem;
-    width: 80%;
-    font-size: 1rem;
-    position: relative;
-    bottom: 1rem;
-  }
-
+  
   /* section */
   .section {
     position: relative;
@@ -500,60 +528,117 @@ footer {
     width: 100%;
   }
   .check img, .search img, .register img {
-    width: 50%;
-    height: auto;
-    padding: 0 2rem;
-  }
-  .bigbox, .bigbox2, .bigbox3 {
     width: 100%;
     height: auto;
+    padding: 0 2rem;
+  } 
+  .bigbox, .bigbox2, .bigbox3 {
+    background-color: var(--white-color);
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     margin: 0;
+    padding: 0;
   }
   .smallbox, .smallbox2, .smallbox3{
     width: 100%;
+    margin: 0;
+    padding: 0 1.5rem;
+    gap: 0.5rem;
+  }
+  .smallbox2{
+    order: 1;
+  }
+  .onetext{
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
   }
   .onetext h2, .onetext2 h2, .onetext3 h2 {
     font-size: 1.5rem;
+    
   }
   .onetext h4, .onetext2 h4, .onetext3 h4{
     font-size: 0.9rem;
+    position: relative;
+    bottom: 1.5rem;
+    white-space: pre-line;
+    
   }
   .smallbox h5, .smallbox2 h5, .smallbox3 h5{
     position: relative;
     top: 0.7rem;
   }
+  .sectionBr{
+    display: inline-block;
+    content: " ";
+    padding: 0 0.3rem;
+  }
 
   /* panda2 */
   .up_footer{
-    height: 16rem;
+    width: 100%;;
   }
   .upFooterIn{
-    position: relative;
-    padding: 0 2rem;
+    width: 100%;
+
   }
   .trustdiv{
     width: 100%;
-    position: relative;
-    left: 1rem;
-    bottom: 2rem;
+    position: absolute;
+    top: 0.1rem;
   }
   .trustdiv h1 {
-    font-size: 1.5rem;
-  }
-  .upFooterIn{
-    width: 100%;
-    height: auto;
+    font-size: 2rem;
+    text-align: center;
   }
   .up_footer img{
-    padding: 0 0 0 2rem;
     width: 100%;
     height: auto;
   }
   /* footer */
-  .footerbox {
-    font-size: 0.7rem;
+  .copy_txt{
+    font-size: 0.5rem;
   }
-  .sns_a img {
+  .footer_a{
+    font-size: 0.5rem;
+  }
+  .footerbox {
+    width: 100%;
+    font-size: 0.7rem;
+    padding: 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 1rem;
+  }
+  .sns_a img{
+    width: 80%;
+  }
+}
+
+/* br 제거 */
+@media screen and (max-width: 430px){
+  .navBr{
+    display: block !important;
+    
+  }
+  .header img{
+    display: none;
+  }
+  .header{
     width: 100%;
   }
-} /* Mobile */
+  .sub_header h2{
+  margin: 0;
+  }
+  .copy_txt{
+    order: 3;
+    width: 100%; 
+    position: relative;
+    right: 7.2rem;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-<>
   <meta charset="UTF-8">
   <!-- 공유 meta tag -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+<head>
   <meta charset="UTF-8">
   <!-- 공유 meta tag -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -46,15 +47,15 @@
           <button type="button">구경하러 가기</button>
         </a>
       </div>
-      <div>
-        <img src="img/header.png">
+      <div class="purchaseImgDiv">
+        <img class="purchaseImg" src="img/header.png">
       </div>
     </div>
   </div>
   <div class="section">
     <div class="check">
       <div class="bigbox">
-        <img src="img/section 1.png">
+        <img class= "checkImg"" src="img/section 1.png">
         <div class="smallbox">
           <h5>Hot item</h5>
           <div class="onetext">
@@ -73,12 +74,12 @@
             <h4>구매하고 싶은 물품은 검색해서<br>쉽게 찾아보세요</h4>
           </div>
         </div>
-      <img src="img/section 2.png">
+        <img class="searchImg" class="searchImg" src="img/section 2.png">
       </div>
     </div>
     <div class="register">
       <div class="bigbox3">
-        <img src="img/section 3.png">
+        <img class="registerImg" src="img/section 3.png">
         <div class="smallbox3">
           <h5>Register</h5>
           <div class="onetext3">
@@ -93,11 +94,13 @@
     <div></div>
   </div>
   <div class="up_footer">
-    <div>
+    <div class="upFooterIn">
       <div class="trustdiv">
         <h1>믿을 수 있는<br>판다마켓 중고 거래</h1>
       </div>
-      <img src="img/footer.png">
+      <div class="footerImgBox">
+        <img class="footerImg" src="img/footer.png">
+      </div>
     </div>
   </div>
   <footer>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
           <img class="pandaImg" src="img/pandaFace.png" alt="판다마켓">
         </a>
         <h1>판다마켓</h1>
+        <h2>자유게시판</h2>
+        <h2>중고마켓</h2>
+      </div>
       </div>
       <a href="login/login.html" target="_self" class="a_button">
         <button type="button" class="login_btn">로그인</button>
@@ -42,14 +45,12 @@
   <div class="purchase">
     <div class="panda_1">
       <div class="perdiv">
-        <h1>일상의 모든 물건을<br>거래해 보세요</h1>
+        <h1>일상의 모든 물건을<br class="navBr">거래해 보세요</h1>
         <a href="items/index.html" target="_self">
           <button type="button">구경하러 가기</button>
         </a>
       </div>
-      <div class="purchaseImgDiv">
-        <img class="purchaseImg" src="img/header.png">
-      </div>
+      <img class="purchaseImg" src="img/header.png">
     </div>
   </div>
   <div class="section">
@@ -59,7 +60,7 @@
         <div class="smallbox">
           <h5>Hot item</h5>
           <div class="onetext">
-            <h2>인기 상품을<br>확인해 보세요</h2>
+            <h2>인기 상품을<br class="sectionBr">확인해 보세요</h2>
             <h4>가장 HOT한 중고거래 물품을<br>판다 마켓에서 확인해 보세요</h4>
           </div>
         </div>
@@ -70,7 +71,7 @@
         <div class="smallbox2">
           <h5>Search</h5>
           <div class="onetext2">
-            <h2>구매를 원하는<br>상품을 검색하세요</h2>
+            <h2>구매를 원하는<br class="sectionBr">상품을 검색하세요</h2>
             <h4>구매하고 싶은 물품은 검색해서<br>쉽게 찾아보세요</h4>
           </div>
         </div>
@@ -83,7 +84,7 @@
         <div class="smallbox3">
           <h5>Register</h5>
           <div class="onetext3">
-            <h2>판매를 원하는<br>상품을 등록하세요</h2>
+            <h2>판매를 원하는<br class="sectionBr">상품을 등록하세요</h2>
             <h4>어떤 물건이든 판매하고 싶은 상품을<br>쉽게 등록학세요</h4>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -119,5 +119,6 @@
       </div>
     </div>
   </footer>
+  <script src="index.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+<>
   <meta charset="UTF-8">
+  <!-- 공유 meta tag -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="아직 미숙한 첫번 째 웹 사이트">
+  <meta property="og:title" content="판다마켓">
+  <meta property="og:url" content="https://ldy-sprint12.netlify.app/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ldy-sprint12.netlify.app/img/panda.png">
+  <meta property="og:description" content="일상에서 모든 물건을 거래해보세요">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-ELV3FDXL1B"></script>
   <script>

--- a/login/login.css
+++ b/login/login.css
@@ -116,14 +116,14 @@ label input:focus {
   border-color: var(--blue-color);
 }
 #password{
-  margin-bottom: 3rem;
+  margin-bottom: 0.5rem;
 }
 #eyeImg {
   width: 1.5rem;
   height: 1.5rem;
   position: relative;
   left: 36.875rem;
-  bottom: 6.3rem;
+  bottom: 3.9rem;
 }
 
 form button {

--- a/login/login.css
+++ b/login/login.css
@@ -217,3 +217,7 @@ footer a {
   position: relative;
   bottom: 2.5rem;
 }
+
+.btnColor {
+  background-color: var(--blue-color);
+}

--- a/login/login.css
+++ b/login/login.css
@@ -21,6 +21,17 @@
 	--secondary-color-blue: #3182F6;
 }
 
+body{
+  margin: 0 auto;
+  width: 100%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+/* header */
 header {
   display: flex;
   flex-direction: row;
@@ -52,8 +63,11 @@ nav h1 {
   line-height: 5.5975rem;
   text-align: left;
   color: var(--blue-color);
+  white-space: nowrap;
 }
 
+
+/* main */
 main {
   display: flex;
   flex-direction: column;
@@ -70,6 +84,7 @@ form {
   gap: 1.25rem;
 }
 
+/* login */
 label {
   display: flex;
   flex-direction: column;
@@ -100,13 +115,15 @@ label input:focus {
   border: solid 2px;
   border-color: var(--blue-color);
 }
-
+#password{
+  margin-bottom: 3rem;
+}
 #eyeImg {
   width: 1.5rem;
   height: 1.5rem;
   position: relative;
   left: 36.875rem;
-  bottom: 3.4rem;
+  bottom: 6.3rem;
 }
 
 form button {
@@ -125,6 +142,7 @@ form button {
   color: var(--white-color);
 }
 
+/* imgbox */
 .imgbox {
   width: 40rem;
   height: 4.625rem;
@@ -147,8 +165,11 @@ form button {
   text-align: left;
   color: var(--secondary-color-black);
   margin-left: 1.4375rem;
+  white-space: nowrap;
 }
-
+.imgbox a{
+  white-space: nowrap;
+}
 #google {
   display: flex;
   justify-content: center;
@@ -172,6 +193,7 @@ form button {
   margin-right: 1.875rem;
 }
 
+/* fotter */
 footer {
   margin-top: 1.25rem;
   margin-bottom: 20rem;
@@ -220,4 +242,92 @@ footer a {
 
 .btnColor {
   background-color: var(--blue-color);
+}
+/* PC */
+@media screen and (min-width: 1200px){
+
+} 
+
+/* Tablet */
+@media screen and (min-width: 744px) and (max-width: 1199px){
+
+}
+
+/* Mobile */
+@media screen and (min-width: 375px) and (max-width: 743px){
+  /* nav */
+  header{
+    padding-top: 0.7rem;
+    margin-bottom: 0.1rem;
+  }
+  nav{
+    padding: 0 6.4rem;
+  }
+  nav img{
+    width: 3rem;
+    height: auto;
+    border-radius: 1rem;
+  }
+  nav h1{
+    font-size: 2rem;
+  }
+  
+
+  /* login */
+  main{
+    max-width: 25rem;
+    padding: 0 1rem;
+  }
+  section{
+    position: relative;
+    bottom: 2rem;
+  }
+  #email, #password{
+    width: 22rem;
+    padding: 1rem 1rem;
+  }
+  #password{
+    margin-bottom: 0.1rem;
+  }
+  .login_box h4{
+    font-size: 0.8rem;
+  }
+  .login_box button{
+    width: 22rem;
+
+  }
+  #eyeImg{
+    position: relative;
+    left: 19rem;
+    bottom: 3.7rem;
+  }
+  
+  /* imgbox */
+  .imgbox{
+    width: 22rem;
+    padding: 0 1rem;
+    justify-content: flex-start;
+    position: relative;
+    bottom: 4rem;
+  }
+  .imgbox h4{
+    font-size: 0.9rem;
+  }
+  #google, #kakao{
+    position: relative;
+    padding: 1rem;
+    right: 16rem;
+  }
+  #google{
+    right: 17rem;
+  }
+  #kakao{
+    padding-top: 1.2rem;
+  }
+  footer{
+    width: 22rem;
+    margin: 0 1rem;
+    position: relative;
+    bottom: 3rem;
+  }
 }

--- a/login/login.css
+++ b/login/login.css
@@ -248,7 +248,7 @@ footer a {
 .modal{
   display: none;
   position: fixed;
-  bottom: 5rem;
+  bottom: 1rem;
   z-index: 1;
   width: 100%;
   height: 100%;

--- a/login/login.css
+++ b/login/login.css
@@ -243,6 +243,60 @@ footer a {
 .btnColor {
   background-color: var(--blue-color);
 }
+
+/* modal */
+.modal{
+  display: none;
+  position: fixed;
+  bottom: 5rem;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.modalBoxStyle{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  background-color: var(--white-color);
+  margin: 30rem auto;
+  padding-top: 7rem;
+  border-radius: 0.8rem;
+  width: 34rem;
+  height: 15.6rem;
+  bottom: 5rem;
+}
+
+.modalH1Style{
+  font-family: Pretendard;
+  font-size: 1.8rem;
+  line-height: 2rem;
+  color: var(--secondary-color-black);
+  text-align: center;
+  position: relative;
+  top: 5rem;
+}
+
+.modalInputStyle{
+  position: relative;
+  top: 3rem;
+  right: 1.5rem;
+  background-color: var(--blue-color);
+  color: var(--white-color);
+  border: none;
+  border-radius: 0.5rem;
+  width: 7.5rem;
+  height: 3rem;
+  font-size: 1rem;
+  font-family: Pretendard;
+  line-height: 2rem;
+  align-self: end;
+  cursor: pointer;
+}
+
 /* PC */
 @media screen and (min-width: 1200px){
 

--- a/login/login.css
+++ b/login/login.css
@@ -96,7 +96,7 @@ label input {
 }
 
 label input:focus {
-  outline: none !important;
+  outline: none;
   border: solid 2px;
   border-color: var(--blue-color);
 }
@@ -112,7 +112,8 @@ label input:focus {
 form button {
   width: 40rem;
   padding: 1rem 7.75rem;
-  gap: 0.625rem;
+  position: relative;
+  bottom: 2rem;
   border-radius: 2.5rem;
   border: none;
   background-color: var(--secondary-color-gray100);
@@ -134,6 +135,8 @@ form button {
   justify-content: space-between;
   align-items: center;
   background-color: var(--secondary-color-gray300);
+  position: relative;
+  bottom: 1.5rem;
 }
 
 .imgbox h4 {
@@ -194,4 +197,23 @@ footer a {
   text-align: left;
   color: var(--secondary-color-blue);
   padding-left: 0.4375rem;
+}
+
+/* js */
+.borderRed {
+  outline: none;
+  border: solid 2px;
+  border-color: red;
+}
+
+.errorMsg {
+  color: red;
+  font-size: 0.8rem;
+  font-family: Pretendard;
+  display: none;
+}
+
+.passwordBottom {
+  position: relative;
+  bottom: 2.5rem;
 }

--- a/login/login.html
+++ b/login/login.html
@@ -66,6 +66,6 @@
     <span>판다마켓이 처음이신가요?</span>
     <a href="../signup/signup.html">회원가입</a>
   </footer>
-  <script src="login.js"></script>
+  <script src="login.js" type="module"></script>
 </body>
 </html>

--- a/login/login.html
+++ b/login/login.html
@@ -36,11 +36,11 @@
       <form>
         <label>
           <h4>이메일</h4>
-          <input type="email" name="email" placeholder="이메일을 입력해주세요">
+          <input id = "email" type="email" name="email" placeholder="이메일을 입력해주세요">
         </label>
         <label>
           <h4>비밀번호</h4>
-          <input type="password" name="password" placeholder="비밀번호를 입력해주세요">
+          <input id = "password" type="password" name="password" placeholder="비밀번호를 입력해주세요">
           <img src="../img/eyeshape.png" id="eyeImg">
         </label>
         <button type="submit" name="login">로그인</button>
@@ -66,5 +66,6 @@
     <span>판다마켓이 처음이신가요?</span>
     <a href="../signup/signup.html">회원가입</a>
   </footer>
+  <script src="login.js"></script>
 </body>
 </html>

--- a/login/login.html
+++ b/login/login.html
@@ -43,7 +43,7 @@
           <input id = "password" type="password" name="password" placeholder="비밀번호를 입력해주세요">
           <img src="../img/eyeshape.png" id="eyeImg">
         </label>
-        <button type="submit" name="login">로그인</button>
+        <button id="loginBtn" type="button" name="login">로그인</button>
       </form>
     </section>
     <section class="imgbox">

--- a/login/login.html
+++ b/login/login.html
@@ -21,7 +21,7 @@
 <body>
   <header>
     <nav>
-      <div>
+      <div class="navIn">
         <a href="../index.html" target="_self">
           <img src="../img/panda.png">
         </a>

--- a/login/login.js
+++ b/login/login.js
@@ -15,6 +15,7 @@ const passwordLabelEl = labelEl[1];
 const emailEl = document.querySelector('#email');
 const passwordEl = document.querySelector('#password');
 const btnEl = document.querySelector('#loginBtn');
+const eyeImgEl = document.querySelector('#eyeImg');
 
 /* setting variable and fixing html  */
 const emailNewP = document.createElement('p');
@@ -98,8 +99,17 @@ function conditionalBtn() {
   } 
 }
 
+function passwordToggle() {
+  if(passwordEl.type === 'password'){
+    passwordEl.setAttribute('type', 'text');
+  } else{
+    passwordEl.setAttribute('type', 'password');
+  }
+}
+
 /* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);
 formEl.addEventListener('focusout', btnDisabled);
 btnEl.addEventListener('click', conditionalBtn);
+eyeImgEl.addEventListener('click', passwordToggle);

--- a/login/login.js
+++ b/login/login.js
@@ -1,27 +1,13 @@
-const USER_DATA = [
-  { email: 'codeit1@codeit.com', password: "codeit101!" },
-  { email: 'codeit2@codeit.com', password: "codeit202!" },
-  { email: 'codeit3@codeit.com', password: "codeit303!" },
-  { email: 'codeit4@codeit.com', password: "codeit404!" },
-  { email: 'codeit5@codeit.com', password: "codeit505!" },
-  { email: 'codeit6@codeit.com', password: "codeit606!" },
-];
+import {USER_DATA, formEl, labelEl, emailEl, passwordEl, passwordToggle,
+  focusoutEmail
+} from '../module.js';
 
 /* getting element */
-const formEl = document.querySelector('form');
-const labelEl = document.querySelectorAll('label')
-const emailLabelEl = labelEl[0];
 const passwordLabelEl = labelEl[1];
-const emailEl = document.querySelector('#email');
-const passwordEl = document.querySelector('#password');
 const btnEl = document.querySelector('#loginBtn');
 const eyeImgEl = document.querySelector('#eyeImg');
 
 /* setting variable and fixing html  */
-const emailNewP = document.createElement('p');
-emailNewP.classList.add("errorMsg");
-emailLabelEl.append(emailNewP);
-
 const passwordNewP = document.createElement('p');
 passwordNewP.classList.add('errorMsg');
 passwordNewP.classList.add('passwordBottom')
@@ -30,28 +16,7 @@ passwordLabelEl.append(passwordNewP);
 btnEl.setAttribute('disabled', true);
 
 /* event handler */
-function validateEmail(email) {
-  const emailPattern = /^[^\s@]+@[^\s@]+\.(com)$/;
-  return emailPattern.test(email);
-}
 
-function focusoutEmail() {
-  if(emailEl.value === ""){ 
-    emailEl.classList.add('borderRed');
-    emailNewP.textContent = "이메일을 입력해주세요.";
-    emailNewP.style.display = 'block';
-    return false;
-  } else if(!validateEmail(emailEl.value)) {
-    emailEl.classList.add('borderRed');
-    emailNewP.textContent = "잘못된 이메일 형식입니다.";
-    emailNewP.style.display = 'block';
-    return false;
-  } else {
-    emailEl.classList.remove('borderRed');
-    emailNewP.style.display = 'none';
-    return true;
-  }
-}
 
 function focusoutPassword() {
   if(passwordEl.value === "") {
@@ -98,15 +63,6 @@ function conditionalBtn() {
     btnEl.addEventListener('click', clickLink);
   } 
 }
-
-function passwordToggle() {
-  if(passwordEl.type === 'password'){
-    passwordEl.setAttribute('type', 'text');
-  } else{
-    passwordEl.setAttribute('type', 'password');
-  }
-}
-
 /* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);

--- a/login/login.js
+++ b/login/login.js
@@ -1,3 +1,12 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
 /* getting element */
 const formEl = document.querySelector('form');
 const labelEl = document.querySelectorAll('label')
@@ -76,8 +85,21 @@ function clickLink(){
   location.href = '../items/index.html';
 } 
 
+function conditionalBtn() {
+  const emailCheck = USER_DATA.some(e => emailEl.value === e.email);
+  const passwordCheck = USER_DATA.some(e => passwordEl.value === e.password);
+  
+  if(!emailCheck){
+    alert('이메일이 존재하지 않습니다.');
+  } else if(emailCheck && !passwordCheck){
+    alert('비밀번호가 일치하지 않습니다.');
+  } else {
+    btnEl.addEventListener('click', clickLink);
+  } 
+}
+
 /* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);
 formEl.addEventListener('focusout', btnDisabled);
-btnEl.addEventListener('click', clickLink);
+btnEl.addEventListener('click', conditionalBtn);

--- a/login/login.js
+++ b/login/login.js
@@ -1,9 +1,13 @@
+/* getting element */
+const formEl = document.querySelector('form');
 const labelEl = document.querySelectorAll('label')
 const emailLabelEl = labelEl[0];
 const passwordLabelEl = labelEl[1];
 const emailEl = document.querySelector('#email');
 const passwordEl = document.querySelector('#password');
+const btnEl = document.querySelector('#loginBtn');
 
+/* setting variable and fixing html  */
 const emailNewP = document.createElement('p');
 emailNewP.classList.add("errorMsg");
 emailLabelEl.append(emailNewP);
@@ -13,7 +17,9 @@ passwordNewP.classList.add('errorMsg');
 passwordNewP.classList.add('passwordBottom')
 passwordLabelEl.append(passwordNewP);
 
+btnEl.setAttribute('disabled', true);
 
+/* event handler */
 function validateEmail(email) {
   const emailPattern = /^[^\s@]+@[^\s@]+\.(com)$/;
   return emailPattern.test(email);
@@ -24,13 +30,16 @@ function focusoutEmail() {
     emailEl.classList.add('borderRed');
     emailNewP.textContent = "이메일을 입력해주세요.";
     emailNewP.style.display = 'block';
+    return false;
   } else if(!validateEmail(emailEl.value)) {
     emailEl.classList.add('borderRed');
     emailNewP.textContent = "잘못된 이메일 형식입니다.";
     emailNewP.style.display = 'block';
+    return false;
   } else {
     emailEl.classList.remove('borderRed');
     emailNewP.style.display = 'none';
+    return true;
   }
 }
 
@@ -39,16 +48,36 @@ function focusoutPassword() {
     passwordEl.classList.add('borderRed');
     passwordNewP.textContent = '비밀번호를 입력해주세요.';
     passwordNewP.style.display = 'block';
+    return false;
   } else if(passwordEl.value.length < 8) {
     passwordEl.classList.add('borderRed');
     passwordNewP.textContent = '비밀번호를 8자 이상 입력해주세요.';
     passwordNewP.style.display = 'block';
+    return false;
   } else {
     passwordEl.classList.remove('borderRed');
     passwordNewP.style.display = 'none';
+    return true;
   }
 }
 
+function btnDisabled() {
+  const emailFunc = focusoutEmail();
+  const passwordFunc = focusoutPassword();
+  if(emailFunc && passwordFunc) {
+    btnEl.disabled = false;
+    btnEl.classList.add('btnColor');
+  } else{
+    btnEl.disabled = true;
+  }
+}
 
+function clickLink(){
+  location.href = '../items/index.html';
+} 
+
+/* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);
+formEl.addEventListener('focusout', btnDisabled);
+btnEl.addEventListener('click', clickLink);

--- a/login/login.js
+++ b/login/login.js
@@ -1,5 +1,5 @@
 import {USER_DATA, formEl, labelEl, emailEl, passwordEl, passwordToggle,
-  focusoutEmail
+  focusoutEmail, modal, modalH1, modalInput, closeModal
 } from '../module.js';
 
 /* getting element */
@@ -16,7 +16,6 @@ passwordLabelEl.append(passwordNewP);
 btnEl.setAttribute('disabled', true);
 
 /* event handler */
-
 
 function focusoutPassword() {
   if(passwordEl.value === "") {
@@ -56,13 +55,20 @@ function conditionalBtn() {
   const passwordCheck = USER_DATA.some(e => passwordEl.value === e.password);
   
   if(!emailCheck){
-    alert('이메일이 존재하지 않습니다.');
+    //alert('이메일이 존재하지 않습니다.');
+    modal.style.display = 'block';
+    modalH1.textContent = '이메일이 존재하지 않습니다.';
+    modalInput.addEventListener('click', closeModal);
   } else if(emailCheck && !passwordCheck){
-    alert('비밀번호가 일치하지 않습니다.');
+    //alert('비밀번호가 일치하지 않습니다.');
+    modal.style.display = 'block';
+    modalH1.textContent = '비밀번호가 일치하지 않습니다.';
+    modalInput.addEventListener('click', closeModal);
   } else {
     btnEl.addEventListener('click', clickLink);
   } 
 }
+
 /* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);

--- a/login/login.js
+++ b/login/login.js
@@ -1,0 +1,54 @@
+const labelEl = document.querySelectorAll('label')
+const emailLabelEl = labelEl[0];
+const passwordLabelEl = labelEl[1];
+const emailEl = document.querySelector('#email');
+const passwordEl = document.querySelector('#password');
+
+const emailNewP = document.createElement('p');
+emailNewP.classList.add("errorMsg");
+emailLabelEl.append(emailNewP);
+
+const passwordNewP = document.createElement('p');
+passwordNewP.classList.add('errorMsg');
+passwordNewP.classList.add('passwordBottom')
+passwordLabelEl.append(passwordNewP);
+
+
+function validateEmail(email) {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.(com)$/;
+  return emailPattern.test(email);
+}
+
+function focusoutEmail() {
+  if(emailEl.value === ""){ 
+    emailEl.classList.add('borderRed');
+    emailNewP.textContent = "이메일을 입력해주세요.";
+    emailNewP.style.display = 'block';
+  } else if(!validateEmail(emailEl.value)) {
+    emailEl.classList.add('borderRed');
+    emailNewP.textContent = "잘못된 이메일 형식입니다.";
+    emailNewP.style.display = 'block';
+  } else {
+    emailEl.classList.remove('borderRed');
+    emailNewP.style.display = 'none';
+  }
+}
+
+function focusoutPassword() {
+  if(passwordEl.value === "") {
+    passwordEl.classList.add('borderRed');
+    passwordNewP.textContent = '비밀번호를 입력해주세요.';
+    passwordNewP.style.display = 'block';
+  } else if(passwordEl.value.length < 8) {
+    passwordEl.classList.add('borderRed');
+    passwordNewP.textContent = '비밀번호를 8자 이상 입력해주세요.';
+    passwordNewP.style.display = 'block';
+  } else {
+    passwordEl.classList.remove('borderRed');
+    passwordNewP.style.display = 'none';
+  }
+}
+
+
+emailEl.addEventListener('focusout', focusoutEmail);
+passwordEl.addEventListener('focusout', focusoutPassword);

--- a/module.js
+++ b/module.js
@@ -1,0 +1,56 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
+/* getting element */
+const formEl = document.querySelector('form');
+const labelEl = document.querySelectorAll('label')
+const emailLabelEl = labelEl[0];
+const emailEl = document.querySelector('#email');
+const passwordEl = document.querySelector('#password');
+
+/* setting variable and fixing html  */
+const emailNewP = document.createElement('p');
+emailNewP.classList.add("errorMsg");
+emailLabelEl.append(emailNewP);
+
+/* event handler */
+function validateEmail(email) {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.(com)$/;
+  return emailPattern.test(email);
+}
+
+function focusoutEmail() {
+  if(emailEl.value === ""){ 
+    emailEl.classList.add('borderRed');
+    emailNewP.textContent = "이메일을 입력해주세요.";
+    emailNewP.style.display = 'block';
+    return false;
+  } else if(!validateEmail(emailEl.value)) {
+    emailEl.classList.add('borderRed');
+    emailNewP.textContent = "잘못된 이메일 형식입니다.";
+    emailNewP.style.display = 'block';
+    return false;
+  } else {
+    emailEl.classList.remove('borderRed');
+    emailNewP.style.display = 'none';
+    return true;
+  }
+}
+
+function passwordToggle() {
+  if(passwordEl.type === 'password'){
+    passwordEl.setAttribute('type', 'text');
+  } else{
+    passwordEl.setAttribute('type', 'password');
+  }
+}
+
+export {USER_DATA, formEl, labelEl, emailLabelEl, emailEl, passwordEl, emailNewP,
+  validateEmail, passwordToggle, focusoutEmail
+};

--- a/module.js
+++ b/module.js
@@ -51,6 +51,29 @@ function passwordToggle() {
   }
 }
 
+/* modal */
+const mainEl = document.querySelector('main');
+const modal = document.createElement('div');
+modal.classList.add('modal');
+const modalBox = document.createElement('div');
+modalBox.classList.add('modalBoxStyle');
+const modalH1 = document.createElement('h1');
+modalH1.classList.add('modalH1style');
+const modalInput = document.createElement('input');
+modalInput.classList.add('modalInputStyle');
+modalInput.setAttribute('type', 'button');
+modalInput.setAttribute('value', '확인')  
+mainEl.after(modal);
+modal.append(modalBox)
+modalBox.append(modalH1);
+modalBox.append(modalInput);
+
+function closeModal(){
+  modal.style.display = 'none';
+}
+
+/* modul */
 export {USER_DATA, formEl, labelEl, emailLabelEl, emailEl, passwordEl, emailNewP,
-  validateEmail, passwordToggle, focusoutEmail
+  validateEmail, passwordToggle, focusoutEmail, modal, modalH1,
+  modalInput, closeModal
 };

--- a/node_modules/unit-fns/src/index.ts
+++ b/node_modules/unit-fns/src/index.ts
@@ -1,0 +1,19 @@
+import * as _unary from 'unit-fns/src/lib/unary'
+import * as _binary from 'unit-fns/src/lib/binary'
+import * as _ternary from 'unit-fns/src/lib/ternary'
+export const unary = _unary
+export const binary = _binary
+export const ternary = _ternary
+
+export * from 'unit-fns/src/lib/core'
+export * from 'unit-fns/src/lib/unary'
+export * from 'unit-fns/src/lib/binary'
+export * from 'unit-fns/src/lib/ternary'
+export * from 'unit-fns/src/lib/number'
+export * from 'unit-fns/src/lib/other'
+
+// TODO:
+// https://iquilezles.org/articles/functions/
+// http://www.flong.com/archive/texts/code/shapers_poly/
+// http://www.flong.com/archive/texts/code/shapers_exp/
+// http://www.flong.com/archive/texts/code/shapers_circ/

--- a/node_modules/unit-fns/src/lib/binary.ts
+++ b/node_modules/unit-fns/src/lib/binary.ts
@@ -1,0 +1,81 @@
+import { Unit } from 'unit-fns/src/lib/core'
+import { radiansToUnit, wrapInclusive } from 'unit-fns/src/lib/number'
+import { unitMax } from 'unit-fns/src/lib/core'
+import { unitMin } from 'unit-fns/src/lib/core'
+
+// TODO: the reverse
+export const angle = (x: Unit, y: Unit): Unit => {
+  return radiansToUnit(Math.atan(y / x))
+}
+
+export const distance = (x: Unit, y: Unit): Unit => {
+  return Math.sqrt(x * x + y * y) / Math.SQRT2
+}
+
+export const maximum = Math.max as (x: Unit, y: Unit) => Unit
+
+export const minimum = Math.min as (x: Unit, y: Unit) => Unit
+
+export const offset = (amount: Unit, unit: Unit): Unit => {
+  return wrapInclusive(amount + unit)
+}
+
+export const peak = (peak: Unit, unit: Unit): Unit => {
+  return unit < peak ? unit / peak : ((unit - peak) * -1) / (1 - peak) + 1
+}
+
+// TODO: is this unit and should it be in this dir?
+export const radial = (x: number, y: number) => {
+  return 1 - distance(x * 2 - 1, y * 2 - 1)
+}
+
+export const repeat = (scale: Unit, t: Unit): Unit => {
+  const times = 1 / scale
+  return (t * times) % 1
+}
+
+export const threshold = (threshold: Unit, t: Unit): Unit => {
+  return t < threshold ? unitMin : unitMax
+}
+
+export const multiply = (a: number, b: number) => {
+  return a * b
+}
+export const screen = (a: number, b: number) => {
+  return 1 - (1 - a) * (1 - b)
+}
+export const darken = (a: number, b: number) => {
+  return Math.min(a, b)
+}
+export const lighten = (a: number, b: number) => {
+  return Math.max(a, b)
+}
+export const difference = (a: number, b: number) => {
+  return Math.abs(a - b)
+}
+export const exclusion = (a: number, b: number) => {
+  return a + b - 2 * a * b
+}
+export const overlay = (a: number, b: number) => {
+  return a < 0.5 ? 2.0 * a * b : 1.0 - 2.0 * (1.0 - a) * (1.0 - b)
+}
+export const hardLight = (a: number, b: number) => {
+  return b < 0.5 ? 2.0 * a * b : 1.0 - 2.0 * (1.0 - a) * (1.0 - b)
+}
+export const softLight = (a: number, b: number) => {
+  return b < 0.5
+    ? 2.0 * a * b + a * a * (1.0 - 2.0 * b)
+    : Math.sqrt(a) * (2.0 * b - 1.0) + 2.0 * a * (1.0 - b)
+}
+export const colorDodge = (a: number, b: number) => {
+  return a / (1.0 - b)
+}
+export const linearDodge = (a: number, b: number) => {
+  return a + b
+}
+export const burn = (a: number, b: number) => {
+  return 1.0 - (1 - a) / b
+}
+export const linearBurn = (a: number, b: number) => {
+  return a + b - 1.0
+}

--- a/node_modules/unit-fns/src/lib/number.ts
+++ b/node_modules/unit-fns/src/lib/number.ts
@@ -1,0 +1,59 @@
+import { Unit, isUnit } from 'unit-fns/src/lib/core'
+
+import { HALF_PI } from 'unit-fns/src/lib/constants'
+
+export const clip = (value: number): Unit => {
+  return Math.max(0, Math.min(1, value))
+}
+
+export const degreesToUnit = (degrees: number): Unit => {
+  return wrap(degrees / 360)
+}
+
+export const fraction = (value: number): Unit => {
+  return 1 / value
+}
+
+export const fractional = (value: number): Unit => {
+  return Math.abs(value % 1)
+}
+
+export const mapRange = (
+  inMin: number,
+  inMax: number,
+  outMin: number,
+  outMax: number,
+  value: number
+): number => {
+  return ((value - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin
+}
+
+export const mapToUnit = (
+  inMin: number,
+  inMax: number,
+  value: number
+): Unit => {
+  return mapRange(inMin, inMax, 0, 1, value)
+}
+
+export const radiansToUnit = (radians: number): Unit => {
+  return wrap(radians / HALF_PI)
+}
+
+export const toIndex = (length: number, unit: Unit): number => {
+  return Math.floor(unit * (length - 1))
+}
+
+export const wrap = (value: number): Unit => {
+  if (isUnit(value)) return value
+
+  return value < 0 ? 1 - (-value % 1) : value % 1
+}
+
+export const wrapInclusive = (value: number): Unit => {
+  if (isUnit(value)) return value
+
+  if (value % 1 === 0) return 1
+
+  return value < 0 ? 1 - (-value % 1) : value % 1
+}

--- a/node_modules/unit-fns/src/lib/other.ts
+++ b/node_modules/unit-fns/src/lib/other.ts
@@ -1,0 +1,68 @@
+import { Unit, unitMax } from 'unit-fns/src/lib/core'
+import { repeat } from 'unit-fns/src/lib/binary'
+import { fraction, toIndex } from 'unit-fns/src/lib/number'
+
+export const branch = (
+  a: (unit: Unit) => Unit,
+  b: (unit: Unit) => Unit,
+  unit: Unit
+) => {
+  return unit > 0.5 ? b(unit) : a(unit)
+}
+
+export const fit = (fns: Array<(unit: Unit) => Unit>, unit: Unit): Unit => {
+  const fnsLength = fns.length
+  const t = repeat(fraction(fnsLength), unit)
+  const fn = fns[toIndex(fnsLength, unit)]
+
+  return fn(t)
+}
+
+export const fitSteps = (steps: Array<Unit>, unit: Unit): Unit => {
+  return steps[toIndex(steps.length, unit)]
+}
+
+export const createBands = (fn: typeof Math.round) => (
+  fraction: Unit,
+  value: Unit
+): Unit => {
+  if (fraction === 0) return value
+
+  const bands = unitMax / fraction
+
+  return fn(value * bands) / bands
+}
+
+export const quantize = createBands(Math.floor)
+
+export const sampleUnaryFn = (
+  length: number,
+  onSample: (unit: Unit) => Unit
+) => {
+  const lookupTable = Array(length)
+
+  for (let i = 0; i < length; i++) {
+    lookupTable[i] = onSample(i / length)
+  }
+  return lookupTable
+}
+
+export const lookup = <T>(unit: Unit, lookupTable: Array<T>): T => {
+  return lookupTable[toIndex(lookupTable.length, unit)]
+}
+
+export const createTiles = (
+  gridX: number,
+  gridY: number,
+  fn3d: (x: Unit, y: Unit, z: Unit) => Unit
+) => {
+  const fractionX = 1 / gridX
+  const fractionY = 1 / gridY
+
+  const frac = 2 / (gridX + gridY)
+
+  return (x: Unit, y: Unit): Unit => {
+    const z = quantize(fractionY, y) + quantize(fractionX, x) * frac
+    return fn3d(repeat(fractionX, x), repeat(fractionY, y), z)
+  }
+}

--- a/node_modules/unit-fns/src/lib/unary.ts
+++ b/node_modules/unit-fns/src/lib/unary.ts
@@ -1,0 +1,68 @@
+import { Unit } from 'unit-fns/src/lib/core'
+import { HALF_PI } from 'unit-fns/src/lib/constants'
+
+export const bounce = (x: Unit): Unit => {
+  const n1 = 7.5625
+  const d1 = 2.75
+
+  if (x < 1 / d1) {
+    return n1 * x * x
+  } else if (x < 2 / d1) {
+    const a = x - 1.5 / d1
+    return n1 * a * a + 0.75
+  } else if (x < 2.5 / d1) {
+    const a = x - 2.25 / d1
+    return n1 * a * a + 0.9375
+  } else {
+    const a = x - 2.625 / d1
+    return n1 * a * a + 0.984375
+  }
+}
+
+export const sine = (x: Unit): Unit => {
+  return Math.sin(x * HALF_PI)
+}
+
+export const cosine = (x: Unit): Unit => {
+  return Math.cos(x * HALF_PI)
+}
+
+export const triangle = (x: Unit): Unit => {
+  return 1 - Math.abs(x * 2 - 1)
+}
+
+export const center = (x: Unit): Unit => {
+  return Math.abs(x * 2 - 1)
+}
+
+export const circular = (x: Unit): Unit => {
+  return 1 - Math.sqrt(1 - Math.pow(x, 2))
+}
+
+export const invert = (x: Unit): Unit => {
+  return 1 - x
+}
+
+export const exponential = (x: Unit): Unit => {
+  return x === 0 ? 0 : Math.pow(2, 10 * x - 10)
+}
+
+export const linear = (x: Unit): Unit => {
+  return x
+}
+
+export const quadratic = (x: Unit): Unit => {
+  return x * x
+}
+
+export const cubic = (x: Unit): Unit => {
+  return x * x * x
+}
+
+export const quartic = (x: Unit): Unit => {
+  return x * x * x * x
+}
+
+export const quintic = (x: Unit): Unit => {
+  return x * x * x * x * x
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "2-sprint-mission-fe",
+  "version": "1.0.0",
+  "description": "================================================================\r ##Mission 1\r - Randing page(Panda Market)\r ----------------------------------------------------------------\r ##Mission 2\r - Log-in page(Panda Market)\r - Sign-up page(Panda Market)",
+  "main": "index.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/signup/signup.css
+++ b/signup/signup.css
@@ -122,6 +122,8 @@ form button {
   line-height: 1.5625rem;
   text-align: center;
   color: var(--white-color);
+  position: relative;
+  bottom: 4rem;
 }
 
 .imgbox {
@@ -134,6 +136,8 @@ form button {
   justify-content: space-between;
   align-items: center;
   background-color: var(--secondary-color-gray300);
+  position: relative;
+  bottom: 3.5rem;
 }
 
 .imgbox h4 {
@@ -198,5 +202,24 @@ footer a {
 
 .password_check {
   position: relative;
-  bottom: 1.25rem;
+  bottom: 2rem;
+}
+
+/* js */
+.borderRed {
+  outline: none;
+  border: solid 2px;
+  border-color: red;
+}
+
+.errorMsg {
+  color: red;
+  font-size: 0.8rem;
+  font-family: Pretendard;
+  display: none;
+}
+
+.passwordBottom {
+  position: relative;
+  bottom: 2.5rem;
 }

--- a/signup/signup.css
+++ b/signup/signup.css
@@ -101,7 +101,15 @@ label input:focus {
   border-color: var(--blue-color);
 }
 
-#eyeImg {
+.eyeImg {
+  width: 1.5rem;
+  height: 1.5rem;
+  position: relative;
+  left: 36.875rem;
+  bottom: 3.4rem;
+}
+
+.checkImg {
   width: 1.5rem;
   height: 1.5rem;
   position: relative;
@@ -222,4 +230,8 @@ footer a {
 .passwordBottom {
   position: relative;
   bottom: 2.5rem;
+}
+
+.btnColor {
+  background-color: var(--blue-color);
 }

--- a/signup/signup.css
+++ b/signup/signup.css
@@ -246,6 +246,59 @@ footer a {
   background-color: var(--blue-color);
 }
 
+/* modal */
+.modal{
+  display: none;
+  position: fixed;
+  bottom: 3rem;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.modalBoxStyle{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  background-color: var(--white-color);
+  margin: 30rem auto;
+  padding-top: 7rem;
+  border-radius: 0.8rem;
+  width: 34rem;
+  height: 15.6rem;
+  bottom: 7.5rem;
+}
+
+.modalH1Style{
+  font-family: Pretendard;
+  font-size: 1.8rem;
+  line-height: 2rem;
+  color: var(--secondary-color-black);
+  text-align: center;
+  position: relative;
+  top: 5rem;
+}
+
+.modalInputStyle{
+  position: relative;
+  top: 3rem;
+  right: 1.5rem;
+  background-color: var(--blue-color);
+  color: var(--white-color);
+  border: none;
+  border-radius: 0.5rem;
+  width: 7.5rem;
+  height: 3rem;
+  font-size: 1rem;
+  font-family: Pretendard;
+  line-height: 2rem;
+  align-self: end;
+  cursor: pointer;
+}
+
 /* PC */
 @media screen and (min-width: 1200px){
 
@@ -335,3 +388,4 @@ footer a {
     bottom: 3rem;
   }
 }
+

--- a/signup/signup.css
+++ b/signup/signup.css
@@ -21,6 +21,16 @@
 	--secondary-color-blue: #3182F6;
 }
 
+body{
+  margin: 0 auto;
+  width: 100%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
 header {
   display: flex;
   flex-direction: row;
@@ -234,4 +244,94 @@ footer a {
 
 .btnColor {
   background-color: var(--blue-color);
+}
+
+/* PC */
+@media screen and (min-width: 1200px){
+
+} 
+
+/* Tablet */
+@media screen and (min-width: 744px) and (max-width: 1199px){
+
+}
+
+/* Mobile */
+@media screen and (min-width: 375px) and (max-width: 743px){
+  /* nav */
+  header{
+    padding-top: 0.7rem;
+    margin-bottom: 0.1rem;
+  }
+  nav{
+    padding: 0 6.4rem;
+  }
+  nav img{
+    width: 3rem;
+    height: auto;
+    border-radius: 1rem;
+  }
+  nav h1{
+    font-size: 2rem;
+  }
+  
+
+  /* login */
+  main{
+    max-width: 25rem;
+    padding: 0 1rem;
+  }
+  section{
+    position: relative;
+    bottom: 2rem;
+  }
+  #email, #password, #nickname, #passwordCheck{
+    width: 22rem;
+    padding: 1rem 1rem;
+  }
+  #password{
+    margin-bottom: 0.1rem;
+  }
+  .login_box h4{
+    font-size: 0.8rem;
+  }
+  .login_box button{
+    width: 22rem;
+
+  }
+  .eyeImg, .checkImg{
+    position: relative;
+    left: 19rem;
+    bottom: 3.5rem;
+  }
+  
+  /* imgbox */
+  .imgbox{
+    width: 22rem;
+    padding: 0 1rem;
+    justify-content: flex-start;
+    position: relative;
+    bottom: 4rem;
+  }
+  .imgbox h4{
+    font-size: 0.9rem;
+    white-space: nowrap;
+  }
+  #google, #kakao{
+    position: relative;
+    padding: 1rem;
+    right: 16rem;
+  }
+  #google{
+    right: 17rem;
+  }
+  #kakao{
+    padding-top: 1.2rem;
+  }
+  footer{
+    width: 22rem;
+    margin: 0 1rem;
+    position: relative;
+    bottom: 3rem;
+  }
 }

--- a/signup/signup.css
+++ b/signup/signup.css
@@ -250,7 +250,7 @@ footer a {
 .modal{
   display: none;
   position: fixed;
-  bottom: 3rem;
+  bottom: 1rem;
   z-index: 1;
   width: 100%;
   height: 100%;

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -36,7 +36,7 @@
       <form>
         <label>
           <h4>이메일</h4>
-          <input type="email" name="email" placeholder="이메일을 입력해주세요">
+          <input id="email" type="email" name="email" placeholder="이메일을 입력해주세요">
         </label>
         <label>
           <h4>닉네임</h4>
@@ -44,12 +44,12 @@
         </label>
         <label>
           <h4>비밀번호</h4>
-          <input type="password" name="password" placeholder="비밀번호를 입력해주세요">
+          <input id="password" type="password" name="password" placeholder="비밀번호를 입력해주세요">
           <img src="../img/eyeshape.png" id="eyeImg">
         </label>
         <label class="password_check">
           <h4>비밀번호 확인</h4>
-          <input type="password" name="password_check" placeholder="비밀번호를 다시 한 번 입력해주세요">
+          <input id="passwordCheck"  type="password" name="password_check" placeholder="비밀번호를 다시 한 번 입력해주세요">
           <img src="../img/eyeshape.png" id="eyeImg">
         </label>
         <button type="submit" name="login">회원가입</button>
@@ -75,5 +75,6 @@
     <span>이미 회원이신가요?</span>
     <a href="../login/login.html">로그인</a>
   </footer>
+  <script src="signup.js"></script>
 </body>
 </html>

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -40,7 +40,7 @@
         </label>
         <label>
           <h4>닉네임</h4>
-          <input type="text" name="nickname" placeholder="닉네임을 입력해주세요">
+          <input id = 'nickname' type="text" name="nickname" placeholder="닉네임을 입력해주세요">
         </label>
         <label>
           <h4>비밀번호</h4>

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -75,6 +75,6 @@
     <span>이미 회원이신가요?</span>
     <a href="../login/login.html">로그인</a>
   </footer>
-  <script src="signup.js"></script>
+  <script src="signup.js" type="module"></script>
 </body>
 </html>

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -45,14 +45,14 @@
         <label>
           <h4>비밀번호</h4>
           <input id="password" type="password" name="password" placeholder="비밀번호를 입력해주세요">
-          <img src="../img/eyeshape.png" id="eyeImg">
+          <img src="../img/eyeshape.png" class="eyeImg">
         </label>
         <label class="password_check">
           <h4>비밀번호 확인</h4>
           <input id="passwordCheck"  type="password" name="password_check" placeholder="비밀번호를 다시 한 번 입력해주세요">
-          <img src="../img/eyeshape.png" id="eyeImg">
+          <img src="../img/eyeshape.png" class="checkImg">
         </label>
-        <button type="submit" name="login">회원가입</button>
+        <button id="signUpBtn" type="button" name="login">회원가입</button>
       </form>
     </section>
     <section class="imgbox">

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,21 +1,11 @@
-const USER_DATA = [
-  { email: 'codeit1@codeit.com', password: "codeit101!" },
-  { email: 'codeit2@codeit.com', password: "codeit202!" },
-  { email: 'codeit3@codeit.com', password: "codeit303!" },
-  { email: 'codeit4@codeit.com', password: "codeit404!" },
-  { email: 'codeit5@codeit.com', password: "codeit505!" },
-  { email: 'codeit6@codeit.com', password: "codeit606!" },
-];
+import {USER_DATA, formEl, labelEl, emailEl, passwordEl, emailNewP,
+  passwordToggle, focusoutEmail
+} from '../module.js';
 
-/* getting element */
-const formEl = document.querySelector('form');
-const labelEl = document.querySelectorAll('label')
-const emailLabelEl = labelEl[0];
+/* getting element */;
 const nicknameLabelEl = labelEl[1];
 const passwordLabelEl = labelEl[2];
 const passwordCheckLabelEl = labelEl[3];
-const emailEl = document.querySelector('#email');
-const passwordEl = document.querySelector('#password');
 const nicknameEl = document.querySelector('#nickname');
 const passwordCheckEl = document.querySelector('#passwordCheck');
 const btnEl = document.querySelector('#signUpBtn');
@@ -23,10 +13,6 @@ const eyeImgFirstEl = document.querySelector('.eyeImg');
 const eyeImgSecondEl = document.querySelector('.checkImg');
 
 /* setting variable and fixing html  */
-const emailNewP = document.createElement('p');
-emailNewP.classList.add("errorMsg");
-emailLabelEl.append(emailNewP);
-  
 const passwordNewP = document.createElement('p');
 passwordNewP.classList.add('errorMsg');
 passwordNewP.classList.add('passwordBottom')
@@ -44,29 +30,6 @@ nicknameLabelEl.append(nicknameNewP);
 btnEl.setAttribute('disabled', true);
 
 /* event handler */
-function validateEmail(email) {
-  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailPattern.test(email);
-}
-
-function focusoutEmail() {
-  if(emailEl.value === ""){ 
-    emailEl.classList.add('borderRed');
-    emailNewP.textContent = "이메일을 입력해주세요.";
-    emailNewP.style.display = 'block';
-    return false;
-  } else if(!validateEmail(emailEl.value)) {
-    emailEl.classList.add('borderRed');
-    emailNewP.textContent = "잘못된 이메일 형식입니다.";
-    emailNewP.style.display = 'block';
-    return false;
-  } else {
-    emailEl.classList.remove('borderRed');
-    emailNewP.style.display = 'none';
-    return true;
-  }
-}
-
 function focusoutPassword() {
   if(passwordEl.value === "") {
     passwordEl.classList.add('borderRed');
@@ -135,14 +98,6 @@ function conditionalBtn(){
     alert('사용 중인 이메일입니다.')
   } else {
     btnEl.addEventListener('click', loginLink);
-  }
-}
-
-function passwordToggle() {
-  if(passwordEl.type === 'password'){
-    passwordEl.setAttribute('type', 'text');
-  } else{
-    passwordEl.setAttribute('type', 'password');
   }
 }
 

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,0 +1,73 @@
+const labelEl = document.querySelectorAll('label')
+const emailLabelEl = labelEl[0];
+const passwordLabelEl = labelEl[2];
+const passwordCheckLabelEl = labelEl[3];
+const emailEl = document.querySelector('#email');
+const passwordEl = document.querySelector('#password');
+const passwordCheckEl = document.querySelector('#passwordCheck');
+
+const emailNewP = document.createElement('p');
+emailNewP.classList.add("errorMsg");
+emailLabelEl.append(emailNewP);
+
+const passwordNewP = document.createElement('p');
+passwordNewP.classList.add('errorMsg');
+passwordNewP.classList.add('passwordBottom')
+passwordLabelEl.append(passwordNewP);
+
+const passwordCheckNewP = document.createElement('p');
+passwordCheckNewP.classList.add('errorMsg');
+passwordCheckNewP.classList.add('passwordBottom');
+passwordCheckLabelEl.append(passwordCheckNewP);
+
+
+function validateEmail(email) {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.(com)$/;
+  return emailPattern.test(email);
+}
+
+function focusoutEmail() {
+  if(emailEl.value === ""){ 
+    emailEl.classList.add('borderRed');
+    emailNewP.textContent = "이메일을 입력해주세요.";
+    emailNewP.style.display = 'block';
+  } else if(!validateEmail(emailEl.value)) {
+    emailEl.classList.add('borderRed');
+    emailNewP.textContent = "잘못된 이메일 형식입니다.";
+    emailNewP.style.display = 'block';
+  } else {
+    emailEl.classList.remove('borderRed');
+    emailNewP.style.display = 'none';
+  }
+}
+
+function focusoutPassword() {
+  if(passwordEl.value === "") {
+    passwordEl.classList.add('borderRed');
+    passwordNewP.textContent = '비밀번호를 입력해주세요.';
+    passwordNewP.style.display = 'block';
+  } else if(passwordEl.value.length < 8) {
+    passwordEl.classList.add('borderRed');
+    passwordNewP.textContent = '비밀번호를 8자 이상 입력해주세요.';
+    passwordNewP.style.display = 'block';
+  } else {
+    passwordEl.classList.remove('borderRed');
+    passwordNewP.style.display = 'none';
+  }
+}
+
+function focusoutPasswordCheck() {
+  if(passwordCheckEl.value !== passwordEl.value) {
+    passwordCheckEl.classList.add('borderRed');
+    passwordCheckNewP.textContent = '비밀번호가 일치하지 않습니다.';
+    passwordCheckNewP.style.display = 'block';
+  } else {
+    passwordCheckEl.classList.remove('borderRed');
+    passwordCheckNewP.style.display = 'none';
+  }
+}
+
+
+emailEl.addEventListener('focusout', focusoutEmail);
+passwordEl.addEventListener('focusout', focusoutPassword);
+passwordCheckEl.addEventListener('focusout', focusoutPasswordCheck);

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,5 +1,6 @@
-import {USER_DATA, formEl, labelEl, emailEl, passwordEl, emailNewP,
-  passwordToggle, focusoutEmail
+import {USER_DATA, formEl, labelEl, emailEl, passwordEl,
+  passwordToggle, focusoutEmail, modal, modalH1, modalInput,
+  closeModal
 } from '../module.js';
 
 /* getting element */;
@@ -95,7 +96,10 @@ function conditionalBtn(){
   const emailCheck = USER_DATA.some(e => emailEl.value === e.email);
 
   if(emailCheck) {
-    alert('사용 중인 이메일입니다.')
+    modal.style.display = 'block';
+    modalH1.textContent = '사용 중인 이메일입니다.';
+    modalInput.addEventListener('click', closeModal); 
+    //alert('사용 중인 이메일입니다.')
   } else {
     btnEl.addEventListener('click', loginLink);
   }

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -19,6 +19,8 @@ const passwordEl = document.querySelector('#password');
 const nicknameEl = document.querySelector('#nickname');
 const passwordCheckEl = document.querySelector('#passwordCheck');
 const btnEl = document.querySelector('#signUpBtn');
+const eyeImgFirstEl = document.querySelector('.eyeImg');
+const eyeImgSecondEl = document.querySelector('.checkImg');
 
 /* setting variable and fixing html  */
 const emailNewP = document.createElement('p');
@@ -136,6 +138,22 @@ function conditionalBtn(){
   }
 }
 
+function passwordToggle() {
+  if(passwordEl.type === 'password'){
+    passwordEl.setAttribute('type', 'text');
+  } else{
+    passwordEl.setAttribute('type', 'password');
+  }
+}
+
+function passwordCheckToggle() {
+  if(passwordCheckEl.type === 'password'){
+    passwordCheckEl.setAttribute('type', 'text');
+  } else{
+    passwordCheckEl.setAttribute('type', 'password');
+  }
+}
+
 /* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);
@@ -143,3 +161,5 @@ nicknameEl.addEventListener('focusout', foucusoutNickname);
 passwordCheckEl.addEventListener('focusout', focusoutPasswordCheck);
 formEl.addEventListener('focusout', btnDisabled);
 btnEl.addEventListener('click', conditionalBtn);
+eyeImgFirstEl.addEventListener('click', passwordToggle);
+eyeImgSecondEl.addEventListener('click', passwordCheckToggle);

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,3 +1,5 @@
+/* getting element */
+const formEl = document.querySelector('form');
 const labelEl = document.querySelectorAll('label')
 const emailLabelEl = labelEl[0];
 const passwordLabelEl = labelEl[2];
@@ -5,11 +7,13 @@ const passwordCheckLabelEl = labelEl[3];
 const emailEl = document.querySelector('#email');
 const passwordEl = document.querySelector('#password');
 const passwordCheckEl = document.querySelector('#passwordCheck');
+const btnEl = document.querySelector('#signUpBtn');
 
+/* setting variable and fixing html  */
 const emailNewP = document.createElement('p');
 emailNewP.classList.add("errorMsg");
 emailLabelEl.append(emailNewP);
-
+  
 const passwordNewP = document.createElement('p');
 passwordNewP.classList.add('errorMsg');
 passwordNewP.classList.add('passwordBottom')
@@ -20,9 +24,11 @@ passwordCheckNewP.classList.add('errorMsg');
 passwordCheckNewP.classList.add('passwordBottom');
 passwordCheckLabelEl.append(passwordCheckNewP);
 
+btnEl.setAttribute('disabled', true);
 
+/* event handler */
 function validateEmail(email) {
-  const emailPattern = /^[^\s@]+@[^\s@]+\.(com)$/;
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailPattern.test(email);
 }
 
@@ -31,13 +37,16 @@ function focusoutEmail() {
     emailEl.classList.add('borderRed');
     emailNewP.textContent = "이메일을 입력해주세요.";
     emailNewP.style.display = 'block';
+    return false;
   } else if(!validateEmail(emailEl.value)) {
     emailEl.classList.add('borderRed');
     emailNewP.textContent = "잘못된 이메일 형식입니다.";
     emailNewP.style.display = 'block';
+    return false;
   } else {
     emailEl.classList.remove('borderRed');
     emailNewP.style.display = 'none';
+    return true;
   }
 }
 
@@ -46,13 +55,16 @@ function focusoutPassword() {
     passwordEl.classList.add('borderRed');
     passwordNewP.textContent = '비밀번호를 입력해주세요.';
     passwordNewP.style.display = 'block';
+    return false;
   } else if(passwordEl.value.length < 8) {
     passwordEl.classList.add('borderRed');
     passwordNewP.textContent = '비밀번호를 8자 이상 입력해주세요.';
     passwordNewP.style.display = 'block';
+    return false;
   } else {
     passwordEl.classList.remove('borderRed');
     passwordNewP.style.display = 'none';
+    return true;
   }
 }
 
@@ -61,13 +73,33 @@ function focusoutPasswordCheck() {
     passwordCheckEl.classList.add('borderRed');
     passwordCheckNewP.textContent = '비밀번호가 일치하지 않습니다.';
     passwordCheckNewP.style.display = 'block';
+    return false;
   } else {
     passwordCheckEl.classList.remove('borderRed');
     passwordCheckNewP.style.display = 'none';
+    return true;
   }
 }
 
+function btnDisabled() {
+  const emailFunc = focusoutEmail();
+  const passwordFunc = focusoutPassword();
+  const passwordCheckFunc = focusoutPasswordCheck();
+  if(emailFunc && passwordFunc && passwordCheckFunc) {
+    btnEl.disabled = false;
+    btnEl.classList.add('btnColor');
+  } else{
+    btnEl.disabled = true;
+  }
+}
 
+function clickLink(){
+  location.href = '../items/index.html';
+} 
+
+/* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);
 passwordCheckEl.addEventListener('focusout', focusoutPasswordCheck);
+formEl.addEventListener('focusout', btnDisabled);
+btnEl.addEventListener('click', clickLink);

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,11 +1,22 @@
+const USER_DATA = [
+  { email: 'codeit1@codeit.com', password: "codeit101!" },
+  { email: 'codeit2@codeit.com', password: "codeit202!" },
+  { email: 'codeit3@codeit.com', password: "codeit303!" },
+  { email: 'codeit4@codeit.com', password: "codeit404!" },
+  { email: 'codeit5@codeit.com', password: "codeit505!" },
+  { email: 'codeit6@codeit.com', password: "codeit606!" },
+];
+
 /* getting element */
 const formEl = document.querySelector('form');
 const labelEl = document.querySelectorAll('label')
 const emailLabelEl = labelEl[0];
+const nicknameLabelEl = labelEl[1];
 const passwordLabelEl = labelEl[2];
 const passwordCheckLabelEl = labelEl[3];
 const emailEl = document.querySelector('#email');
 const passwordEl = document.querySelector('#password');
+const nicknameEl = document.querySelector('#nickname');
 const passwordCheckEl = document.querySelector('#passwordCheck');
 const btnEl = document.querySelector('#signUpBtn');
 
@@ -23,6 +34,10 @@ const passwordCheckNewP = document.createElement('p');
 passwordCheckNewP.classList.add('errorMsg');
 passwordCheckNewP.classList.add('passwordBottom');
 passwordCheckLabelEl.append(passwordCheckNewP);
+
+const nicknameNewP = document.createElement('p');
+nicknameNewP.classList.add('errorMsg');
+nicknameLabelEl.append(nicknameNewP);
 
 btnEl.setAttribute('disabled', true);
 
@@ -81,11 +96,25 @@ function focusoutPasswordCheck() {
   }
 }
 
+function foucusoutNickname(){
+  if(nicknameEl.value === ""){
+    nicknameEl.classList.add('borderRed');
+    nicknameNewP.textContent = '닉네임을 입력해주세요.';
+    nicknameNewP.style.display = 'block';
+    return false;
+  } else {
+    nicknameEl.classList.remove('borderRed');
+    nicknameNewP.style.display = 'none';
+    return true;
+  }
+}
+
 function btnDisabled() {
   const emailFunc = focusoutEmail();
   const passwordFunc = focusoutPassword();
   const passwordCheckFunc = focusoutPasswordCheck();
-  if(emailFunc && passwordFunc && passwordCheckFunc) {
+  const nicknameFunc = foucusoutNickname();
+  if(emailFunc && passwordFunc && passwordCheckFunc && nicknameFunc) {
     btnEl.disabled = false;
     btnEl.classList.add('btnColor');
   } else{
@@ -93,13 +122,24 @@ function btnDisabled() {
   }
 }
 
-function clickLink(){
-  location.href = '../items/index.html';
-} 
+function loginLink(){
+  location.href = '../login/login.html'
+}
+
+function conditionalBtn(){
+  const emailCheck = USER_DATA.some(e => emailEl.value === e.email);
+
+  if(emailCheck) {
+    alert('사용 중인 이메일입니다.')
+  } else {
+    btnEl.addEventListener('click', loginLink);
+  }
+}
 
 /* event handling */ 
 emailEl.addEventListener('focusout', focusoutEmail);
 passwordEl.addEventListener('focusout', focusoutPassword);
+nicknameEl.addEventListener('focusout', foucusoutNickname);
 passwordCheckEl.addEventListener('focusout', focusoutPasswordCheck);
 formEl.addEventListener('focusout', btnDisabled);
-btnEl.addEventListener('click', clickLink);
+btnEl.addEventListener('click', conditionalBtn);


### PR DESCRIPTION
## 기본 요구사항
### 공통

- [x] Github에 스프린트 미션 PR을 만들어 주세요.
- [x] 로그인, 회원가입 페이지 공통

- [x] 로그인 및 회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.

- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.

- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다

- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.

- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.

- [x] Input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.

- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

### 로그인 페이지

- [x] 이메일과 비밀번호를 입력하고 로그인 버튼을 누른 후, 다음 조건을 참조하여 로그인 성공 여부를 alert 메시지로 출력합니다.
만약 입력한 이메일이 데이터베이스(USER_DATA)에 없거나, 이메일은 일치하지만 비밀번호가 틀린 경우, '비밀번호가 일치하지 않습니다.'라는 메시지를 alert로 표시합니다
- [x] 만약 입력한 이메일이 데이터베이스에 존재하고, 비밀번호도 일치할 경우, “/items”로 이동합니다.
회원가입

- [x] 회원가입을 위해 이메일, 닉네임, 비밀번호, 비밀번호 확인을 입력한 뒤, 회원가입 버튼을 클릭하세요. 그 후에는 다음 조건에 따라 회원가입 가능 여부를 alert로 알려주세요.
- [x] 입력한 이메일이 이미 데이터베이스(USER_DATA)에 존재하는 경우, '사용 중인 이메일입니다'라는 메시지를 alert로 표시합니다.
- [x] 입력한 이메일이 데이터베이스(USER_DATA)에 없는 경우, 회원가입이 성공적으로 처리되었으므로 로그인 페이지(”/login”)로 이동합니다.

``` const USER_DATA = [
    { email: 'codeit1@codeit.com', password: "codeit101!" },
    { email: 'codeit2@codeit.com', password: "codeit202!" },
    { email: 'codeit3@codeit.com', password: "codeit303!" },
    { email: 'codeit4@codeit.com', password: "codeit404!" },
    { email: 'codeit5@codeit.com', password: "codeit505!" },
    { email: 'codeit6@codeit.com', password: "codeit606!" },
]; 
```
## 심화 요구사항
### 공통

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 판다마켓 랜딩 페이지(“/”) 공유 시 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정합니다.

- [x] 미리보기에서 제목은 “판다마켓”, 설명은 “일상에서 모든 물건을 거래해보세요”로 설정합니다.

- [x] 주소와 이미지는 자유롭게 설정하세요.

- [x] 로그인, 회원가입 페이지에 공통으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.

### 랜딩 페이지

- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 744px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 743px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

- [x] Tablet 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.

- [x] Mobile 사이즈로 작아질 때 최소 좌우 여백이 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.

- [x] PC, Tablet 사이즈의 이미지 크기는 고정값을 사용합니다.

- [x] Mobile 사이즈의 이미지는 좌우 여백 32px을 제외하고 이미지 영역이 꽉 차게 구현합니다. (이때 가로가 커지는 비율에 맞춰 세로도 커져야 합니다.)

- [x] Mobile 사이즈 너비가 커지면, “Privacy Policy”, “FAQ”, “codeit-2023”이 있는 영역과 SNS 아이콘들이 있는 영역의 사이 간격이 커집니다.

### 로그인, 회원가입 페이지 공통

- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.

- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.

- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

- [x] 오류 메시지 모달을 구현합니다. 모달 내 내용은 alert 메시지와 동일합니다.

- [x] 비밀번호 및 비밀번호 확인 입력란에 눈 모양 아이콘 클릭 시 비밀번호 표시/숨기기 토글이 가능합니다. 기본 상태는 비밀번호 숨김으로 설정합니다.

## 스크린샷
![image](https://github.com/user-attachments/assets/0581eceb-3778-4002-a223-ba2bfc3bd5a1)
![image](https://github.com/user-attachments/assets/f9e5e929-c37c-4df6-9c01-e8b82d20cb63)


## Netlify 주소

https://ldy-sprint12.netlify.app/

## 주요 변경사항
- 만약 입력한 이메일이 데이터베이스(USER_DATA)에 없을 때 '비밀번호가 일치하지 않습니다.'가 아닌 '이메일이 존재하지 않습니다.'라고 변경했습니다.

- 회원가입 페이지에서 닉네임 input에 대한 조건이 없어서 input에 값이 없을 때  input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보이게 만들었습니다.

- 회원가입 페이지에서 버튼을 활성화 하려면 닉네임 input에도 값을 넣어야 활성화 되도록 수정했습니다.

## 멘토에게

- 기능적으로 잘 구현됬는지 궁금합니다.

- 제 코드가 실무에서도 적용할 수 있도록 전체적인 형식에 대한 리뷰가 필요합니다.
